### PR TITLE
Fix Antenna Manipulation Bug

### DIFF
--- a/app/static/js/Editor.js
+++ b/app/static/js/Editor.js
@@ -385,28 +385,28 @@ Editor.prototype = {
 
 	select: function ( object ) {
 		if ( this.selected === object ) return;
-		
-		if(this.scene == object || this.scene === object.parent){
+
+		if(object === null || this.scene == object || this.scene === object.parent){
 			var uuid = null;
 
 			if ( object !== null ) {
-	
+
 				uuid = object.uuid;
-	
+
 			}
 
 			this.selected = object;
 
 			this.config.setKey( 'selected', uuid );
 			this.signals.objectSelected.dispatch( object );
-			
+
 		} else {
 			var uuid = null;
 
 			if ( object.parent !== null ) {
-	
+
 				uuid = object.parent.uuid;
-	
+
 			}
 
 			this.selected = object.parent;

--- a/app/static/js/Menubar.Add.js
+++ b/app/static/js/Menubar.Add.js
@@ -63,7 +63,7 @@ Menubar.Add = function ( editor ) {
     input_pane.add(new UI.Break());
 
 	// Antenna
-	
+
 	var option = new UI.Row();                    // basic point for antenna representation
 	option.setClass( 'option' );
 	option.setTextContent( 'Antenna' );
@@ -123,6 +123,7 @@ Menubar.Add = function ( editor ) {
             }
             var mesh = new THREE.Mesh( geometry, material );
             mesh.name = 'Antenna' + ( ++meshCount );
+            mesh.type = "Antenna";
 
             editor.execute( new SetPositionCommand( mesh, new THREE.Vector3( x_NG, y_NG, z_NG ) ) );     // move object to desired coordinates
 

--- a/app/static/js/Sidebar.Object.js
+++ b/app/static/js/Sidebar.Object.js
@@ -469,7 +469,7 @@ Sidebar.Object = function ( editor ) {
 
             }
 
-            if ( (editor.getObjectMaterial((object.children)[0])).wireframe !== undefined && (editor.getObjectMaterial((object.children)[0])).wireframe !== materialWireframe.getValue() ){
+            if ( object.type !== "Antenna" && (editor.getObjectMaterial((object.children)[0])).wireframe !== undefined && (editor.getObjectMaterial((object.children)[0])).wireframe !== materialWireframe.getValue() ){
 
                 var objects = object.children;
 
@@ -733,7 +733,11 @@ Sidebar.Object = function ( editor ) {
         objectVisible.setValue( object.visible );
         //Added
         //materialWireframe.setValue(object.Wireframe);
-        materialWireframe.setValue( (editor.getObjectMaterial((object.children)[0])).wireframe );
+        if ( object.type !== "Antenna" ) {
+          console.log(object);
+          materialWireframe.setValue( (editor.getObjectMaterial((object.children)[0])).wireframe );
+        }
+
         try {
 
             objectUserData.setValue( JSON.stringify( object.userData, null, '  ' ) );


### PR DESCRIPTION
The wireframe code expects that all models have a wireframe. This is a poor assumption. Because antennas do not have a wireframe, each time a user manipulated the antenna (rotation, translation, scale), the UI would lock up and throw an error to console. This bugfix corrects this.

This fixes #56 
This also fixes #58 