### PR TITLE
Document API, improve API responses, and improve API security

### DIFF
--- a/app/rest/views.py
+++ b/app/rest/views.py
@@ -44,7 +44,7 @@ def save_state():
     try:
         state = request.get_json(request.data)
         if "project" not in state or "scene" not in state or "camera" not in state or "metadata" not in state:
-            return jsonify({"results": "FAIL", "reason": "BADPOST", "error": "non-valid JSON save state"}), 406
+            return jsonify({"results": "FAIL", "reason": "BADPOST", "error": "non-valid JSON save state"}), 400
         #Check to see if the POSTed save state has a UUID. If not, then this is a new project and we need to generate a UUID for it.
         if "uuid" not in state["project"] or state["project"]["uuid"] == "":
             state["project"]["uuid"] = str(uuid.uuid4())
@@ -56,7 +56,7 @@ def save_state():
     except IOError as error: #Disk error on save
         return jsonify({"results": "FAIL", "reason": "IOERROR", "error": str(error.errno), "errorstring": str(error.strerror)}), 500
     except TypeError as error: #Save state format error
-        return jsonify({"results": "FAIL", "reason": "BADPOST", "error": str(error)}), 406
+        return jsonify({"results": "FAIL", "reason": "BADPOST", "error": str(error)}), 400
     except Exception as error: #Other general error
         return jsonify({"results": "FAIL", "reason": "OTHER", "error": str(error)}), 400
     return jsonify({"results": "FAIL", "reason": "OTHER"}), 400 #How'd we get here? Someone trying to load the page?
@@ -76,11 +76,11 @@ def resume_state(uuid=None):
                     states += save_state[:-5] + "," #Only return the UUID, remove .json ending
             return jsonify({"results": "SUCCESS", "data": str(states[:-1])})
         except Exception as error: #There was an error listing the directory, return general error
-            return jsonify({"results": "FAIL", "reason": "OTHER", "error": str(error)})
+            return jsonify({"results": "FAIL", "reason": "OTHER", "error": str(error)}), 500
     else: #We're requesting a specific UUID to resume from.
         try:
             with open(current_app.config["JSON_STORE_DATA"] + secure_filename(str(uuid))+ ".json", 'r') as save_state_file:
                 return save_state_file.read()
         except Exception as error: #Other general error
-            return jsonify({"results": "FAIL", "reason": "OTHER", "error": str(error)})
+            return jsonify({"results": "FAIL", "reason": "OTHER", "error": str(error)}), 500
     return "FAIL" #How'd we get here?

--- a/app/static/js/Storage.js
+++ b/app/static/js/Storage.js
@@ -90,7 +90,8 @@ var Storage = function () {
         success: function(data) {
           if ( data.results == "SUCCESS" ) {
             console.log('[' + /\d\d\:\d\d\:\d\d/.exec(new Date())[0] + ']', 'Saved state to server as UUID', data.uuid, ( performance.now() - start ).toFixed( 2 ) + 'ms');
-            if ( editor.project_uuid == "" ) {
+            if ( editor.project_uuid  != data.uuid  ) {
+              console.log('[' + /\d\d\:\d\d\:\d\d/.exec(new Date())[0] + ']', 'The UUID changed from', editor.project_uuid, 'to', data.uuid);
               editor.project_uuid = data.uuid; //Set the initial UUID if this the first save-state for this session.
             }
           } else {

--- a/docs/api/fileconversion.md
+++ b/docs/api/fileconversion.md
@@ -1,0 +1,32 @@
+# Server-Side File Conversion
+
+Used to enable file support not native to Three.js
+
+**URL** : `/rest/convert_object/`
+
+**Method** : `POST`
+
+**Auth required** : NO
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+On successful conversion the server will return an .OBJ object as a string to the client.
+
+
+## Error Response
+
+**Condition** : The file could not be converted
+
+**Code** : `500 INTERNAL SERVER ERROR`
+
+**Content** :
+
+The error is returned as a string, in a non-JSON format.
+
+```
+IOError: [Errno 2] No such file or directory
+```

--- a/docs/api/statesave.md
+++ b/docs/api/statesave.md
@@ -1,0 +1,173 @@
+# Server-Side Save State [sending state to server]
+
+Used to keep client state consistent across browsers, as well as to share work/progress.
+
+**URL** : `/rest/save_state/`
+
+**Method** : `POST`
+
+**Auth required** : NO
+
+**Data example**
+
+```
+for a full example of a save state that's POSTED, view tests/resources/good_json_test.json
+```
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+On successful save, the server will return a success message as well as the project UUID. This is used to keep track of a single session. On the first POST of a save state, the server will generate a UUID, save it to the state, and notify the client of it so that both can reference this new state by the UUID.
+
+```json
+{
+  "results": "SUCCESS",
+  "uuid": "486a4c8b-09a8-4480-9728-f4d239bb4a3c"
+}
+```
+
+## Error Response
+
+**Condition** : The save state was improperly formatted, or other bad POST related action
+
+**Code** : `400 BAD REQUEST`
+
+**Content** :
+
+The error field is a string that details the specific POST error that occurred.
+
+```json
+{
+  "results": "FAIL",
+  "reason": "BADPOST",
+  "error": "non-valid JSON save state",
+}
+```
+
+**Condition** : The save state could not be written to disk.
+
+**Code** : `500 INTERNAL SERVER ERROR`
+
+**Content** :
+
+The error field is an int with the Python-related IOError. Some common examples include 13: no permission and 28: disk full. Errorstring is the exception message itself.
+
+```json
+{
+  "results": "FAIL",
+  "reason": "IOERROR",
+  "error": 13,
+  "errorstring": "Permission Denied"
+}
+```
+**Condition** : All other errors not covered above (hardware failure, global thermonuclear warfare-EMP burst)
+
+**Code** : `400 BAD REQUEST`
+
+**Content** :
+
+The error field is a string that details the specific error that was raised.
+
+```json
+{
+  "results": "FAIL",
+  "reason": "OTHER",
+  "error": "god save the queen"
+}
+```
+
+# Server-Side Save State [enumerating states on server]
+
+
+**URL** : `/rest/resume_state`
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data example**
+
+```
+website.com/rest/resume_state/
+```
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+On successful GET, the server will return a list of all the save states on the server, in comma-delimited format. If there are no saves on the server, data will be an empty string.
+
+```json
+{
+  "results": "SUCCESS",
+  "data": "486a4c8b-09a8-4480-9728-f4d239bb4a3c,7ca3ccfd-98d0-4d2c-a2cd-96c3339d7c25,9b88bd30-3ae6-4323-85f9-f739fd26c66b"
+}
+```
+
+## Error Response
+
+**Condition** : The states could not be enumerated.
+
+**Code** : `500 INTERNAL SERVER ERROR`
+
+**Content** :
+
+The error field is a string that details the specific error that was raised. In this example, the save-state folder was deleted while the server was still running.
+
+```json
+{
+  "results": "FAIL",
+  "reason": "OTHER",
+  "error": "No such file or directory",
+}
+```
+
+# Server-Side Save State [fetching a state on server]
+
+
+**URL** : `/rest/resume_state/<uuid>`
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+**Data example**
+
+```
+website.com/rest/resume_state/486a4c8b-09a8-4480-9728-f4d239bb4a3c
+```
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Content example**
+
+On successful GET, the server will return the save state in JSON format.
+
+```
+for a full example of a save state that's returned, view tests/resources/good_json_test.json
+```
+
+## Error Response
+
+**Condition** : The state could not be found or loaded.
+
+**Code** : `500 INTERNAL SERVER ERROR`
+
+**Content** :
+
+The error field is a string that details the specific error that was raised. In this example, the requested save-state does not exist
+
+```json
+{
+  "results": "FAIL",
+  "reason": "OTHER",
+  "error": "No such file or directory",
+}
+```

--- a/docs/api/statesave.md
+++ b/docs/api/statesave.md
@@ -65,7 +65,7 @@ The error field is an int with the Python-related IOError. Some common examples 
 ```
 **Condition** : All other errors not covered above (hardware failure, global thermonuclear warfare-EMP burst)
 
-**Code** : `400 BAD REQUEST`
+**Code** : `500 INTERNAL SERVER ERROR`
 
 **Content** :
 
@@ -123,7 +123,7 @@ The error field is a string that details the specific error that was raised. In 
 {
   "results": "FAIL",
   "reason": "OTHER",
-  "error": "No such file or directory",
+  "error": "No such file or directory"
 }
 ```
 
@@ -168,6 +168,6 @@ The error field is a string that details the specific error that was raised. In 
 {
   "results": "FAIL",
   "reason": "OTHER",
-  "error": "No such file or directory",
+  "error": "No such file or directory"
 }
 ```


### PR DESCRIPTION
Docs for the API are located in docs/api

While documenting, I found some flaws in the endpoints that someone could use to negatively impact the server, including non-proper UUIDs. While we are sanitizing the UUID for file saving, that doesn't stop people from POSTing arbitrary UUIDs and I'd rather avoid that.

Also changed the API so that 406 errors are now 400. I misunderstood the purpose of 406, and some more research has shown me that returning 400 is more common/normal in the case of user-side error.

I changed the behavior of the client-side Storage class to check to see if the UUID has changed, rather than just trusting the first UUID. This allows the client to correct itself if it POSTs a bad UUID. Previously, only checking for empty UUID with a poorly formatted UUID would result in a permanent state of error. Now, the server quietly corrects the UUID, the client notices, and now refers it's current session with the new UUID.

This is a continuation of #20